### PR TITLE
Use gsutil rsync to avoid redownloading static data

### DIFF
--- a/firebase-export/firebase-export-metadata.json
+++ b/firebase-export/firebase-export-metadata.json
@@ -3,6 +3,6 @@
   "firestore": {
     "version": "1.11.4",
     "path": "firebase-export",
-    "metadata_file": "firebase-export/firebase-export.overall_export_metadata"
+    "metadata_file": "firebase-export.overall_export_metadata"
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "build": "concurrently \"yarn build:react\" \"yarn build:functions\" \"yarn build:tts\"",
     "updateSaveFile": "ts-node --project ttsBuild/tsconfig.json ttsBuild/updateSaveFile.ts \"$(wslpath $(powershell.exe '$env:UserProfile') | tr -d '\\r')/Documents/My Games/Tabletop Simulator/Saves/9999.json\"",
     "createConfigFile": "ts-node --project ttsBuild/tsconfig.json ttsBuild/createConfigFile.ts",
-    "downloadWiki": "gsutil -m cp -R gs://adventurecard-game.appspot.com/firebase-export ./firebase-export",
+    "downloadWiki": "gsutil -m rsync -d -r -x firebase-export-metadata.json gs://adventurecard-game.appspot.com/firebase-export/ ./firebase-export",
     "exportWiki": "gcloud firestore export gs://adventurecard-game.appspot.com/firebase-export --collection-ids=wiki,wiki_character,deck,card",
     "importOldCards": "set TS_NODE_PROJECT=dbUtil/tsconfig.json&& node -r ts-node/register --max-old-space-size=10240 dbUtil/importOldCards.ts",
     "test": "react-scripts test",


### PR DESCRIPTION
If we could add the metadata.json file to the gs:// directory, we wouldn't need to exclude it from the rsync. But if we can't for some reason, we have to use the -x flag to skip deleting it.